### PR TITLE
show correct series checkins for each level

### DIFF
--- a/src/components/ClassSeriesForm/checkins.js
+++ b/src/components/ClassSeriesForm/checkins.js
@@ -97,6 +97,11 @@ class ClassSeriesCheckinList extends PureComponent<Props, State> {
           <ReactTable
             data={this.state.classSeriesCheckinList}
             columns={[{
+              Header: "Date",
+              accessor: "date",
+              id: "date",
+              maxWidth: 200
+            }, {
               Header: "Name",
               accessor: (d) => [d.firstName, d.lastName].join(' '),
               id: "name",


### PR DESCRIPTION
There was a bug where the series page showed the check-ins for all classes on those dates instead of just the classes for that particular leveled series. This was an issue with the API call not properly filtering check-ins by level. I also added the date to the check-ins table so that we can better see the check-ins for each day in a series.