### PR TITLE
show correct series checkins for each level

### DIFF
--- a/src/components/ClassSeriesForm/checkins.js
+++ b/src/components/ClassSeriesForm/checkins.js
@@ -97,6 +97,11 @@ class ClassSeriesCheckinList extends PureComponent<Props, State> {
           <ReactTable
             data={this.state.classSeriesCheckinList}
             columns={[{
+              Header: "Date",
+              accessor: "date",
+              id: "date",
+              maxWidth: 200
+            }, {
               Header: "Name",
               accessor: (d) => [d.firstName, d.lastName].join(' '),
               id: "name",


### PR DESCRIPTION
Fixes a bug where check-ins for all classes were showing up where check-ins for only a specific class series should be.

This change is already live in production.