### PR TITLE
hide new student form because we don't use it anymore

### DIFF
--- a/src/components/DanceCheckinForm/form.js
+++ b/src/components/DanceCheckinForm/form.js
@@ -197,6 +197,12 @@ class DanceCheckinForm extends PureComponent<Props, State> {
           />
           <br></br>
           <hr></hr>
+          { !this.state.checkin.email &&
+            <div>
+              <br></br>
+              <p><span role="img" aria-label="Down arrow">⬇️</span> <strong>New dance attendees</strong> please fill out the form below. <span role="img" aria-label="Down arrow">⬇️</span></p>
+            </div>
+          }
           <br></br>
           <FormGroup>
             <Label for="firstName">First Name <span className="required-text">*</span></Label><Input placeholder="First Name" value={this.state.checkin.firstName} onChange={this.onCheckinChange} name="firstName" />

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -70,13 +70,6 @@ class Home extends Component {
             <Row>
               <Col>
                 <Card className="card-body text-center mb-2">
-                  <CardTitle className="front-page-card">New Student Form</CardTitle>
-                  <CardText className="front-page-card">Fill out new student details form.</CardText>
-                  <Link to="/new-student"><Button size="lg">New Student</Button></Link>
-                </Card>
-              </Col>
-              <Col>
-                <Card className="card-body text-center mb-2">
                   <CardTitle className="front-page-card">Returning Student Class Check-in</CardTitle>
                   <CardText className="front-page-card">Returning students check in here.</CardText>
                   <Link to="/class-checkin"><Button size="lg">Class Check-in</Button></Link>

--- a/src/components/ReturningStudentForm/form.js
+++ b/src/components/ReturningStudentForm/form.js
@@ -12,7 +12,6 @@ import { getSubstringIndex, sortByNameAndEmail, getDateFromStringSafe } from "..
 import McsAlert from "../Utilities/alert.js";
 import { CodeOfConductModalLink } from "../Utilities/conductModal.js";
 import { LiabilityWaiverModalLink } from "../Utilities/waiverModal.js";
-import { Link } from 'react-router-dom';
 
 
 type State = ClassCheckin;
@@ -280,14 +279,14 @@ class ReturningStudentForm extends PureComponent<Props, State> {
             onChange={this.onCheckinTypeaheadChange}
             options={this.state.profileList.map((profile) => { return {"id": profile.email, "label": profile.firstName + " " + profile.lastName} })}
           />
+          <br></br>
+          <hr></hr>
           { !this.state.checkin.email &&
             <div>
               <br></br>
-              <Link to="/new-student?redirect=true"><Button color="primary" size="md">New Students Fill Out Form Here</Button></Link>
+              <p><span role="img" aria-label="Down arrow">⬇️</span> <strong>New students</strong> please fill out the form below. <span role="img" aria-label="Down arrow">⬇️</span></p>
             </div>
           }
-          <br></br>
-          <hr></hr>
           <br></br>
           {this.state.checkin.completedFundamentals &&
             <p><strong>{this.state.checkin.firstName} {this.state.checkin.lastName} has completed the MCS fundamentals course.</strong></p>

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -74,9 +74,6 @@ export default class MyNavbar extends Component {
                 </DropdownToggle>
                 <DropdownMenu right>
                   <DropdownItem>
-                    <NavLink href="/new-student">New Student Form</NavLink>
-                  </DropdownItem>
-                  <DropdownItem>
                     <NavLink href="/class-checkin">Class Check-in</NavLink>
                   </DropdownItem>
                 </DropdownMenu>


### PR DESCRIPTION
Changes:
* Remove new student form from navbar
* Remove new student form widget from home page
* Remove new student form button from class check-in page
* Add text directing new students and dancers to the dance/class check-in form