### PR TITLE
split level 2 into 2a and 2b

### DIFF
--- a/src/components/ClassSeriesForm/form.js
+++ b/src/components/ClassSeriesForm/form.js
@@ -184,7 +184,8 @@ class ClassSeriesForm extends PureComponent<Props, State> {
             <Input type="select" name="level" value={this.state.level} onChange={this.onLevelChange}>
               <option value="">-</option>
               <option value="Fundamentals">Fundamentals</option>
-              <option value="Level 2">Level 2</option>
+              <option value="Level 2A">Level 2A</option>
+              <option value="Level 2B">Level 2B</option>
               <option value="Level 3">Level 3</option>
             </Input>
           </FormGroup>

--- a/src/components/NewStudentForm/adminForm.js
+++ b/src/components/NewStudentForm/adminForm.js
@@ -389,6 +389,26 @@ class AdminStudentInfoForm extends PureComponent<Props, State> {
             </FormGroup>
             <FormGroup check>
               <Label check>
+                <Input onChange={this.onMultiTypeChange} type="checkbox" name="classes" checked={this.state.classes.indexOf('Level 2A WCS, Drop-in') !== -1} value="Level 2A WCS, Drop-in" /> {' '} Level 2A WCS, Drop-in
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
+                <Input onChange={this.onMultiTypeChange} type="checkbox" name="classes" checked={this.state.classes.indexOf('Level 2A WCS, Monthly Series') !== -1} value="Level 2A WCS, Monthly Series" /> {' '} Level 2A WCS, Monthly Series
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
+                <Input onChange={this.onMultiTypeChange} type="checkbox" name="classes" checked={this.state.classes.indexOf('Level 2B WCS, Drop-in') !== -1} value="Level 2B WCS, Drop-in" /> {' '} Level 2B WCS, Drop-in
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
+                <Input onChange={this.onMultiTypeChange} type="checkbox" name="classes" checked={this.state.classes.indexOf('Level 2B WCS, Monthly Series') !== -1} value="Level 2B WCS, Monthly Series" /> {' '} Level 2B WCS, Monthly Series
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
                 <Input onChange={this.onMultiTypeChange} type="checkbox" name="classes" checked={this.state.classes.indexOf('Level 3 WCS, Drop-in') !== -1} value="Level 3 WCS, Drop-in" /> {' '} Level 3 WCS, Drop-in
               </Label>
             </FormGroup>

--- a/src/components/ReturningStudentForm/form.js
+++ b/src/components/ReturningStudentForm/form.js
@@ -333,17 +333,12 @@ class ReturningStudentForm extends PureComponent<Props, State> {
             </FormGroup>
             <FormGroup check>
               <Label check>
-                <Input onChange={this.onMultiTypeCheckinChange} type="checkbox" name="classes" checked={this.state.checkin.classes.indexOf('Level 2 WCS, First Class Only') !== -1} value="Level 2 WCS, First Class Only" /> {' '} Level 2 WCS, First Class Only
+                <Input onChange={this.onMultiTypeCheckinChange} type="checkbox" name="classes" checked={this.state.checkin.classes.indexOf('Level 2A WCS, 6-Week Series') !== -1} value="Level 2A WCS, 6-Week Series" /> {' '} Level 2A WCS, 6-Week Series
               </Label>
             </FormGroup>
             <FormGroup check>
               <Label check>
-                <Input onChange={this.onMultiTypeCheckinChange} type="checkbox" name="classes" checked={this.state.checkin.classes.indexOf('Level 2 WCS, 6-Week Series') !== -1} value="Level 2 WCS, 6-Week Series" /> {' '} Level 2 WCS, 6-Week Series
-              </Label>
-            </FormGroup>
-            <FormGroup check>
-              <Label check>
-                <Input onChange={this.onMultiTypeCheckinChange} type="checkbox" name="classes" checked={this.state.checkin.classes.indexOf('Level 3 WCS, First Class Only') !== -1} value="Level 3 WCS, First Class Only" /> {' '} Level 3 WCS, First Class Only
+                <Input onChange={this.onMultiTypeCheckinChange} type="checkbox" name="classes" checked={this.state.checkin.classes.indexOf('Level 2B WCS, 6-Week Series') !== -1} value="Level 2B WCS, 6-Week Series" /> {' '} Level 2B WCS, 6-Week Series
               </Label>
             </FormGroup>
             <FormGroup check>


### PR DESCRIPTION
See the updated class descriptions here: https://missioncityswing.com/classes/

Also removed the option to just take the first class of the L2 and L3 class series.