### PR TITLE
re-add level 2 back to the series form

### DIFF
--- a/src/components/ClassSeriesForm/form.js
+++ b/src/components/ClassSeriesForm/form.js
@@ -184,6 +184,7 @@ class ClassSeriesForm extends PureComponent<Props, State> {
             <Input type="select" name="level" value={this.state.level} onChange={this.onLevelChange}>
               <option value="">-</option>
               <option value="Fundamentals">Fundamentals</option>
+              <option value="Level 2">Level 2</option>
               <option value="Level 2A">Level 2A</option>
               <option value="Level 2B">Level 2B</option>
               <option value="Level 3">Level 3</option>


### PR DESCRIPTION
When I updated the application to split Level 2 into 2A and 2B (#189 ), [I removed the Level 2 option](https://github.com/mission-city-swing/mcs_registration/pull/189/files#diff-bd2587e6c0a731c75225c02a8fe1f5d2755715814f8964c5b28b18a3105e0dfdL187) in the class series form. This was a mistake because sometimes I need to create class series retroactively. This commit re-adds the option to create a class series that is just Level 2. I can revert this commit once we create all the class series that will be _just_ Level 2.